### PR TITLE
Enable agent name lookup in ask endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,17 @@ docker run -p 8000:8000 -e OPENAI_API_KEY=<la tua chiave> rag-carletti
 ```
 
 ## Endpoint /ask
-L'endpoint accetta il campo JSON `query` e, opzionalmente, `agent_id` (o `agent`) per scegliere quale agente deve rispondere. Se il parametro è assente o non valido verrà usato Gustav (id `1`). L'elenco completo degli agenti è consultabile anche con `GET /agents`.
+L'endpoint accetta il campo JSON `query` e, opzionalmente, `agent_id` (o `agent`) per scegliere quale agente deve rispondere. Se il parametro è assente verrà usato Gustav (id `1`). È possibile indicare l'id numerico o il nome dell'agente (non viene fatta distinzione tra maiuscole e minuscole). Se il valore non è riconosciuto l'API restituisce errore `422`. L'elenco completo degli agenti è consultabile con `GET /agents`.
 
-Esempio di richiesta:
+Esempi di richiesta:
 ```bash
 curl -X POST http://localhost:8000/ask \
      -H 'Content-Type: application/json' \
      -d '{"query": "Perché la lavatrice non scarica?", "agent_id": 3}'
+
+curl -X POST http://localhost:8000/ask \
+     -H 'Content-Type: application/json' \
+     -d '{"query": "Consigli per la manutenzione", "agent": "yomo"}'
 ```
 
 ## Aggiornamento dell'indice dei documenti


### PR DESCRIPTION
## Summary
- improve `/ask` handler to allow using agent names
- return a 422 error with agent list if an unrecognized name or id is supplied
- document name-based usage in the README

## Testing
- `python -m py_compile main.py`
- `OPENAI_API_KEY=dummy BING_SEARCH_API_KEY=dummy python main.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687679d273b0832d9420ad0307bd7f9d