### PR TITLE
Handle API errors in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
 
 3. **Avvio dell'applicazione**
    ```bash
-   python main.py
+   uvicorn main:app --reload
    ```
    L'interfaccia web sarà disponibile su `http://127.0.0.1:8000`.
 

--- a/static/index.html
+++ b/static/index.html
@@ -213,10 +213,15 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ query, agent_id: parseInt(agentSelect.value) })
         })
-          .then(resp => resp.json())
-          .then(data => {
+          .then(async resp => {
+            const data = await resp.json();
             document.getElementById('loading').parentElement.remove();
-            addMessage(data.risposta, 'bot');
+            if (resp.ok && data.risposta) {
+              addMessage(data.risposta, 'bot');
+            } else {
+              const msg = data.error || 'Errore interno.';
+              addMessage('❌ ' + msg, 'bot');
+            }
             sendBtn.disabled = false;
             promptInput.focus();
           })

--- a/static/index_responsive.html
+++ b/static/index_responsive.html
@@ -167,9 +167,14 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ query: userText })
         })
-        .then(resp => resp.json())
-        .then(data => {
-          addMessage(data.risposta, 'bot');
+        .then(async resp => {
+          const data = await resp.json();
+          if (resp.ok && data.risposta) {
+            addMessage(data.risposta, 'bot');
+          } else {
+            const msg = data.error || 'Errore interno.';
+            addMessage('❌ ' + msg, 'bot');
+          }
           sendBtn.disabled = false;
           promptInput.focus();
         })


### PR DESCRIPTION
## Summary
- display backend error messages instead of `undefined`
- correct README instructions for running the app with Uvicorn

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6877ba5dd6f4832d8318611bc410a60b