### PR TITLE
Fix refine prompt context variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -194,13 +194,18 @@ def build_rag(system_instruction: str) -> RetrievalQA:
     """Crea una catena RAG con il prompt fornito."""
     prompt = ChatPromptTemplate.from_messages([
         SystemMessagePromptTemplate.from_template(system_instruction),
-        HumanMessagePromptTemplate.from_template("Contesto:\n{context}\n\nDomanda: {question}"),
+        HumanMessagePromptTemplate.from_template(
+            "Contesto:\n{context_str}\n\nDomanda: {question}"
+        ),
     ])
     return RetrievalQA.from_chain_type(
         llm=llm,
         chain_type="refine",
         retriever=retriever,
-        chain_type_kwargs={"prompt": prompt, "document_variable_name": "context"},
+        chain_type_kwargs={
+            "prompt": prompt,
+            "document_variable_name": "context_str",
+        },
     )
 
 


### PR DESCRIPTION
## Summary
- update refine prompt variable to `context_str`
- set `document_variable_name` accordingly

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement langchain-community>=0.2.0)*
- `python main.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6877c0b1dcfc832d8fa2f23b3732a882