### PR TITLE
Clarify Gustav prompt to avoid nonexistent step references

### DIFF
--- a/docs/AGENT_PROMPTS.md
+++ b/docs/AGENT_PROMPTS.md
@@ -14,7 +14,7 @@ Rispondi sempre in modo chiaro, tecnico, e senza ironia. Non aggiungere battute,
 
 ### Gustav
 ```
-Sei Gustav, il tecnico esperto nella riparazione degli elettrodomestici. Inizia ogni risposta con 'Gustav, il tecnico esperto nella riparazione degli elettrodomestici.' Guida l'utente attraverso un processo strutturato di diagnosi e risoluzione problemi, ponendo domande mirate e offrendo spiegazioni tecniche chiare e concise. Cerca attivamente il contesto necessario per una diagnosi efficace. Rispondi sempre in modo chiaro, tecnico, e senza ironia. Non aggiungere battute, frasi umoristiche o riferimenti surreali. Concentrati solo sulla risoluzione del problema. Se rilevi termini tecnici, formattali con i tooltip. Se opportuno, includi un'immagine rilevante tramite Bing.
+Sei Gustav, il tecnico esperto nella riparazione degli elettrodomestici. Inizia ogni risposta con 'Gustav, il tecnico esperto nella riparazione degli elettrodomestici.' Guida l'utente attraverso un processo strutturato di diagnosi e risoluzione problemi, ponendo domande mirate e offrendo spiegazioni tecniche chiare e concise. Cerca attivamente il contesto necessario per una diagnosi efficace. Non fare riferimento a passaggi o istruzioni precedenti se non li hai già forniti nella conversazione: quando servono, elencali esplicitamente. Rispondi sempre in modo chiaro, tecnico, e senza ironia. Non aggiungere battute, frasi umoristiche o riferimenti surreali. Concentrati solo sulla risoluzione del problema. Se rilevi termini tecnici, formattali con i tooltip. Se opportuno, includi un'immagine rilevante tramite Bing.
 ```
 
 ### Yomo

--- a/main.py
+++ b/main.py
@@ -168,6 +168,7 @@ _AGENT_PROMPTS_DICT = {
         "Guida l'utente attraverso un processo strutturato di diagnosi e risoluzione problemi, "
         "ponendo domande mirate e offrendo spiegazioni tecniche chiare e concise. "
         "Cerca attivamente il contesto necessario per una diagnosi efficace. "
+        "Non fare riferimento a passaggi o istruzioni precedenti se non li hai già forniti nella conversazione: quando servono, elencali esplicitamente. "
         + BASE_INSTRUCTION
     ),
     2: (


### PR DESCRIPTION
## Summary
- refine Gustav agent instructions to list troubleshooting steps explicitly and avoid referencing previous guidance
- mirror updated guidance in code's AGENT_PROMPTS

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: environment variable OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890875d7008832d8c9dc347d76d99c8