### PR TITLE
feat: allow specifying OpenAI model via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
    ```
 
 2. **Variabili d'ambiente**
-   Imposta almeno la chiave di OpenAI prima di avviare l'applicazione:
+   Imposta almeno la chiave di OpenAI prima di avviare l'applicazione. È possibile
+   specificare un modello diverso tramite la variabile `OPENAI_MODEL` (predefinito `gpt-5`):
    ```bash
    export OPENAI_API_KEY=<la tua chiave>
    export BING_SEARCH_API_KEY=<opzionale per immagini>
+   export OPENAI_MODEL=<modello opzionale>
    ```
 
 3. **Avvio dell'applicazione**
@@ -49,7 +51,8 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
 # build image
 docker build -t rag-carletti .
 # esegui l'app
-docker run -p 8000:8000 -e OPENAI_API_KEY=<la tua chiave> rag-carletti
+docker run -p 8000:8000 -e OPENAI_API_KEY=<la tua chiave> \
+    -e OPENAI_MODEL=<modello opzionale> rag-carletti
 ```
 
 ## Endpoint /ask

--- a/main.py
+++ b/main.py
@@ -56,7 +56,9 @@ try:
     retriever = db.as_retriever(search_kwargs={"k": 5})
 
     llm = ChatOpenAI(
-        model_name="gpt-3.5-turbo", temperature=0, openai_api_key=OPENAI_API_KEY
+        model_name=os.getenv("OPENAI_MODEL", "gpt-5"),
+        temperature=0,
+        openai_api_key=OPENAI_API_KEY,
     )
 
     BASE_INSTRUCTION = (


### PR DESCRIPTION
## Summary
- allow overriding the OpenAI chat model via `OPENAI_MODEL`
- document new `OPENAI_MODEL` environment variable

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: Devi impostare la variabile d'ambiente OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_689b4cd23368832d959bb816d3c6032a