### PR TITLE
Update OpenAI SDK and related dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 fastapi>=0.95.0
 uvicorn[standard]>=0.22.0
 langchain-community>=0.2.0
-langchain-openai>=0.0.19
+langchain-openai>=0.1.0
 python-dotenv>=1.0.0
-openai>=0.27.0
+openai>=1.0.0
 faiss-cpu>=1.7.4
 tiktoken>=0.5.0
 unstructured>=0.7.0


### PR DESCRIPTION
## Summary
- Upgrade to OpenAI Python SDK 1.0+ to enable GPT-5 access
- Align langchain-openai with the updated OpenAI SDK

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.95.0)*
- `python main.py` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689b4d941f38832d8b515951b0c57bf2