### PR TITLE
feat: make embedding model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
    ```bash
    export OPENAI_API_KEY=<la tua chiave>
    export BING_SEARCH_API_KEY=<opzionale per immagini>
+   export OPENAI_EMBED_MODEL=text-embedding-3-large  # opzionale
    ```
 
 3. **Avvio dell'applicazione**
@@ -70,7 +71,7 @@ curl -X POST http://localhost:8000/ask \
 
 Se modifichi o aggiungi file nella cartella `docs/` devi rigenerare la cartella `vectordb/` per riflettere i nuovi contenuti.
 
-Puoi utilizzare uno dei seguenti script (richiedono entrambi la variabile d'ambiente `OPENAI_API_KEY` impostata):
+Puoi utilizzare uno dei seguenti script (richiedono la variabile d'ambiente `OPENAI_API_KEY` e, facoltativamente, `OPENAI_EMBED_MODEL` per scegliere il modello di embedding, predefinito `text-embedding-3-large`):
 
 ```bash
 python index_documents.py      # indicizza tutti i documenti

--- a/index_documents.py
+++ b/index_documents.py
@@ -18,6 +18,9 @@ if not OPENAI_API_KEY:
         "Devi impostare la variabile d'ambiente OPENAI_API_KEY per usare OpenAIEmbeddings."
     )
 
+# Modello di embedding configurabile tramite variabile d'ambiente
+EMBED_MODEL = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-large")
+
 # 1) Carica tutti i file .txt in docs/ (ricorsivamente)
 txt_loader = DirectoryLoader("docs", glob="**/*.txt", loader_cls=TextLoader)
 
@@ -31,7 +34,9 @@ documents = txt_loader.load()
 
 # 3) Scegli l’embedding di OpenAI
 # Modifica qui: usa OpenAIEmbeddings
-embeddings = OpenAIEmbeddings(openai_api_key=OPENAI_API_KEY)
+embeddings = OpenAIEmbeddings(
+    model=EMBED_MODEL, openai_api_key=OPENAI_API_KEY
+)
 
 # 4) Crea (o ricrea) il database FAISS
 db = FAISS.from_documents(documents, embeddings)
@@ -43,5 +48,5 @@ db.save_local("vectordb/")
 # retriever = db.as_retriever(search_kwargs={"k": 5})  # personalizza k se necessario
 
 print(
-    "✅ Indicizzazione (con tutti i documenti) completata utilizzando OpenAIEmbeddings."
+    f"✅ Indicizzazione completata utilizzando il modello di embedding '{EMBED_MODEL}'."
 )

--- a/rebuild_vectordb.py
+++ b/rebuild_vectordb.py
@@ -11,6 +11,9 @@ load_dotenv()
 # Leggi chiave
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
 
+# Modello di embedding configurabile tramite variabile d'ambiente
+EMBED_MODEL = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-large")
+
 # Prepara documenti
 docs = []
 for file in Path("docs/").rglob("*.txt"):
@@ -18,7 +21,9 @@ for file in Path("docs/").rglob("*.txt"):
     docs.append(Document(page_content=text, metadata={"source": str(file)}))
 
 # Embeddings e FAISS
-embeddings = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"))
+embeddings = OpenAIEmbeddings(
+    model=EMBED_MODEL, openai_api_key=os.getenv("OPENAI_API_KEY")
+)
 faiss_db = FAISS.from_documents(docs, embeddings)
 faiss_db.save_local("vectordb/")
-print("✅ Indice FAISS (dim=1536) ricostruito correttamente.")
+print(f"✅ Indice FAISS ricostruito con il modello {EMBED_MODEL}.")


### PR DESCRIPTION
## Summary
- allow choosing embedding model via `OPENAI_EMBED_MODEL`
- document optional `OPENAI_EMBED_MODEL` variable in README

## Testing
- `python rebuild_vectordb.py` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b4d95ad3c832d916b935951333250