### PR TITLE
feat: make image search optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
    export OPENAI_API_KEY=<la tua chiave>
    export BING_SEARCH_API_KEY=<opzionale per immagini>
    export OPENAI_MODEL=<modello opzionale>
+   export ENABLE_IMAGE_SEARCH=true  # disabilita con false
    ```
 
 3. **Avvio dell'applicazione**
@@ -58,6 +59,8 @@ docker run -p 8000:8000 -e OPENAI_API_KEY=<la tua chiave> \
 ## Endpoint /ask
 L'endpoint accetta il campo JSON `query` e, opzionalmente, `agent_id` (o `agent`) per scegliere quale agente deve rispondere. Se il parametro è assente verrà usato Gustav (id `1`). È possibile indicare l'id numerico o il nome dell'agente (non viene fatta distinzione tra maiuscole e minuscole). Se il valore non è riconosciuto l'API restituisce errore `422`. L'elenco completo degli agenti è consultabile con `GET /agents`.
 
+La ricerca immagini tramite Bing può essere disabilitata globalmente impostando la variabile d'ambiente `ENABLE_IMAGE_SEARCH=false` oppure per singola richiesta passando `"include_image": false` nel payload.
+
 Esempi di richiesta:
 ```bash
 curl -X POST http://localhost:8000/ask \
@@ -66,7 +69,7 @@ curl -X POST http://localhost:8000/ask \
 
 curl -X POST http://localhost:8000/ask \
      -H 'Content-Type: application/json' \
-     -d '{"query": "Consigli per la manutenzione", "agent": "yomo"}'
+     -d '{"query": "Consigli per la manutenzione", "agent": "yomo", "include_image": false}'
 ```
 
 ## Aggiornamento dell'indice dei documenti


### PR DESCRIPTION
## Summary
- add `ENABLE_IMAGE_SEARCH` env var to toggle Bing image lookup
- run Bing search asynchronously and allow per-request disabling
- document image search configuration and request option

## Testing
- `python -m py_compile main.py`
- `time curl -s -o /dev/null -w '%{time_total}\n' -X POST http://localhost:8000/ask -H 'Content-Type: application/json' -d '{"query":"introduzione"}'` (image search enabled)
- `ENABLE_IMAGE_SEARCH=false OPENAI_API_KEY=dummy BING_SEARCH_API_KEY=dummy uvicorn main:app --port 8000 --log-level warning` (server)
- `time curl -s -o /dev/null -w '%{time_total}\n' -X POST http://localhost:8000/ask -H 'Content-Type: application/json' -d '{"query":"introduzione"}'` (image search disabled)

------
https://chatgpt.com/codex/tasks/task_e_689b5c69a06c832d96c56d722da805b7