### PR TITLE
chore: remove Pinecone client dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ openai>=0.27.0
 faiss-cpu>=1.7.4
 tiktoken>=0.5.0
 unstructured>=0.7.0
-pinecone-client>=2.3.0
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- remove pinecone-client from requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.95.0)*
- `OPENAI_API_KEY=dummy python main.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a44d8079cc832da706a38544c4d5e7