### PR TITLE
Support multiple footnote references

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -149,6 +149,12 @@
       color: var(--accent);
     }
 
+    sup:target,
+    .footnotes li:target {
+      background: var(--accent);
+      color: white;
+    }
+
     #loading {
       font-style: italic;
       color: var(--accent);


### PR DESCRIPTION
## Summary
- Track per-term occurrences in `applica_tooltip` and generate unique reference IDs
- Append a ↩ backlink for each occurrence in footnote list items
- Highlight targeted footnotes and references for easier navigation

## Testing
- `python -m py_compile main.py`
- `timeout 5 python main.py` *(fails: Devi impostare la variabile d'ambiente OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a44d849768832dbfa027f1c058773d