### PR TITLE
Sanitize chat messages

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -155,6 +155,7 @@
       margin-top: -10px;
     }
   </style>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
 </head>
 <body>
   <header>
@@ -191,7 +192,18 @@
       function addMessage(text, sender) {
         const msg = document.createElement('div');
         msg.classList.add('message', sender);
-        msg.innerHTML = text;
+        const sanitized = DOMPurify.sanitize(text, {
+          ALLOWED_TAGS: [
+            'a', 'sup', 'img', 'b', 'strong', 'i', 'em', 'code',
+            'p', 'br', 'ul', 'ol', 'li', 'span'
+          ],
+          ALLOWED_ATTR: ['href', 'target', 'rel', 'src', 'alt', 'id', 'class', 'title']
+        });
+        if (sender === 'user') {
+          msg.textContent = sanitized;
+        } else {
+          msg.innerHTML = sanitized;
+        }
         chatContainer.appendChild(msg);
         chatContainer.scrollTop = chatContainer.scrollHeight;
       }


### PR DESCRIPTION
## Summary
- Integrate DOMPurify and sanitize all chat messages
- Display user messages as text content while allowing limited HTML for bot replies

## Testing
- `python main.py` *(fails: Devi impostare la variabile d'ambiente OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a44d86e7a4832dbb31e117bd563230