### PR TITLE
Add DeepSeek provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
    ```
 
 2. **Variabili d'ambiente**
-   Imposta almeno la chiave di OpenAI prima di avviare l'applicazione. È possibile
-   specificare un modello diverso tramite la variabile `OPENAI_MODEL` (predefinito `gpt-5`):
+   È possibile scegliere il provider del modello tramite `LLM_PROVIDER` (`openai` predefinito oppure `deepseek`).
+   Imposta la chiave API corrispondente prima di avviare l'applicazione:
    ```bash
-   export OPENAI_API_KEY=<la tua chiave>
+   export LLM_PROVIDER=openai            # oppure deepseek
+   export OPENAI_API_KEY=<chiave se usi OpenAI>
+   export DEEPSEEK_API_KEY=<chiave se usi DeepSeek>
    export BING_SEARCH_API_KEY=<opzionale per immagini>
    export OPENAI_MODEL=<modello opzionale>
    export ENABLE_IMAGE_SEARCH=true  # disabilita con false
@@ -53,9 +55,13 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
 ```bash
 # build image
 docker build -t rag-carletti .
-# esegui l'app
+# esegui l'app con OpenAI
 docker run -p 8000:8000 -e OPENAI_API_KEY=<la tua chiave> \
-    -e OPENAI_MODEL=<modello opzionale> rag-carletti
+    -e LLM_PROVIDER=openai rag-carletti
+
+# oppure con DeepSeek
+docker run -p 8000:8000 -e DEEPSEEK_API_KEY=<la tua chiave> \
+    -e LLM_PROVIDER=deepseek rag-carletti
 ```
 
 ## Endpoint /ask
@@ -78,7 +84,7 @@ curl -X POST http://localhost:8000/ask \
 
 Se modifichi o aggiungi file nella cartella `docs/` devi rigenerare la cartella `vectordb/` per riflettere i nuovi contenuti.
 
-Puoi utilizzare uno dei seguenti script (richiedono entrambi la variabile d'ambiente `OPENAI_API_KEY` impostata):
+Puoi utilizzare uno dei seguenti script (richiedono la chiave API del provider selezionato):
 
 ```bash
 python index_documents.py      # indicizza i soli file .txt

--- a/index_documents.py
+++ b/index_documents.py
@@ -47,25 +47,44 @@ def main() -> None:
         action="store_true",
         help="Includi anche i PDF (estratti e suddivisi in sezioni)",
     )
+    parser.add_argument(
+        "--provider",
+        default=os.getenv("LLM_PROVIDER", "openai"),
+        choices=["openai", "deepseek"],
+        help="Provider LLM da utilizzare (default: valore di LLM_PROVIDER)",
+    )
     args = parser.parse_args()
 
     load_dotenv()
 
-    # Assicurati che la variabile d'ambiente OPENAI_API_KEY sia disponibile
-    OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-    if not OPENAI_API_KEY:
-        raise Exception(
-            "Devi impostare la variabile d'ambiente OPENAI_API_KEY per usare OpenAIEmbeddings."
+    provider = args.provider.lower()
+    if provider == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise Exception(
+                "Devi impostare la variabile d'ambiente OPENAI_API_KEY oppure usare --provider deepseek"
+            )
+        embeddings = OpenAIEmbeddings(openai_api_key=api_key)
+    else:  # deepseek
+        api_key = os.getenv("DEEPSEEK_API_KEY")
+        base_url = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
+        if not api_key:
+            raise Exception(
+                "Devi impostare la variabile d'ambiente DEEPSEEK_API_KEY per usare --provider deepseek"
+            )
+        embeddings = OpenAIEmbeddings(
+            openai_api_key=api_key,
+            base_url=base_url,
+            default_headers={"Authorization": f"Bearer {api_key}"},
         )
 
     documents = load_txt_documents()
     if args.include_pdf:
         documents.extend(load_pdf_sections())
 
-    embeddings = OpenAIEmbeddings(openai_api_key=OPENAI_API_KEY)
     db = FAISS.from_documents(documents, embeddings)
     db.save_local("vectordb/")
-    print("✅ Indicizzazione completata utilizzando OpenAIEmbeddings.")
+    print(f"✅ Indicizzazione completata utilizzando il provider {provider}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add LLM_PROVIDER to select OpenAI or DeepSeek
- allow indexing scripts to choose provider and use proper API key
- document provider selection and Docker examples

## Testing
- `python -m py_compile main.py index_documents.py rebuild_vectordb.py`
- `LLM_PROVIDER=deepseek python main.py` *(fails: `Devi impostare la variabile d'ambiente DEEPSEEK_API_KEY`)*
- `python main.py` *(fails: `Devi impostare la variabile d'ambiente OPENAI_API_KEY oppure usare LLM_PROVIDER=deepseek`)*

------
https://chatgpt.com/codex/tasks/task_e_68af34479258832d9579f9f0ffcb45a3