### PR TITLE
feat: autodetect deepseek provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
 
 2. **Variabili d'ambiente**
    È possibile scegliere il provider del modello tramite `LLM_PROVIDER` (`openai` predefinito oppure `deepseek`).
+   Se è presente solo `DEEPSEEK_API_KEY` e manca `OPENAI_API_KEY`, il valore di `LLM_PROVIDER` viene impostato automaticamente su `deepseek`.
    Imposta la chiave API corrispondente prima di avviare l'applicazione:
    ```bash
-   export LLM_PROVIDER=openai            # oppure deepseek
+   export LLM_PROVIDER=openai            # oppure deepseek (impostato automaticamente se manca OPENAI_API_KEY)
    export OPENAI_API_KEY=<chiave se usi OpenAI>
    export DEEPSEEK_API_KEY=<chiave se usi DeepSeek>
    export BING_SEARCH_API_KEY=<opzionale per immagini>

--- a/main.py
+++ b/main.py
@@ -47,15 +47,20 @@ DEEPSEEK_BASE_URL = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
 BING_SEARCH_API_KEY = os.getenv("BING_SEARCH_API_KEY")
 ENABLE_IMAGE_SEARCH = os.getenv("ENABLE_IMAGE_SEARCH", "true").lower() == "true"
 
+if DEEPSEEK_API_KEY and not OPENAI_API_KEY:
+    LLM_PROVIDER = "deepseek"
+
 if LLM_PROVIDER not in {"openai", "deepseek"}:
     raise Exception("LLM_PROVIDER deve essere 'openai' o 'deepseek'")
 
 if LLM_PROVIDER == "openai" and not OPENAI_API_KEY:
     raise Exception(
-        "Devi impostare la variabile d'ambiente OPENAI_API_KEY oppure usare LLM_PROVIDER=deepseek"
+        "Variabile OPENAI_API_KEY mancante. Imposta OPENAI_API_KEY e LLM_PROVIDER=openai, oppure fornisci DEEPSEEK_API_KEY e LLM_PROVIDER=deepseek"
     )
 if LLM_PROVIDER == "deepseek" and not DEEPSEEK_API_KEY:
-    raise Exception("Devi impostare la variabile d'ambiente DEEPSEEK_API_KEY")
+    raise Exception(
+        "Variabile DEEPSEEK_API_KEY mancante. Imposta DEEPSEEK_API_KEY e LLM_PROVIDER=deepseek"
+    )
 
 VECTORDB_PATH = "vectordb/"
 if not os.path.isdir(VECTORDB_PATH):


### PR DESCRIPTION
## Summary
- detect DeepSeek automatically when only `DEEPSEEK_API_KEY` is set
- clarify missing-key errors with `LLM_PROVIDER` hints
- document automatic provider selection in README

## Testing
- `DEEPSEEK_API_KEY=dummy python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af372f24a0832daefbc8f434c9b879