### PR TITLE
Auto-select DeepSeek provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
 
 2. **Variabili d'ambiente**
    È possibile scegliere il provider del modello tramite `LLM_PROVIDER` (`openai` predefinito oppure `deepseek`).
+   Se `DEEPSEEK_API_KEY` è presente e `OPENAI_API_KEY` assente, il provider viene impostato automaticamente su `deepseek`.
    Imposta la chiave API corrispondente prima di avviare l'applicazione:
    ```bash
    export LLM_PROVIDER=openai            # oppure deepseek

--- a/main.py
+++ b/main.py
@@ -47,15 +47,23 @@ DEEPSEEK_BASE_URL = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
 BING_SEARCH_API_KEY = os.getenv("BING_SEARCH_API_KEY")
 ENABLE_IMAGE_SEARCH = os.getenv("ENABLE_IMAGE_SEARCH", "true").lower() == "true"
 
+if DEEPSEEK_API_KEY and not OPENAI_API_KEY:
+    LLM_PROVIDER = "deepseek"
+
 if LLM_PROVIDER not in {"openai", "deepseek"}:
     raise Exception("LLM_PROVIDER deve essere 'openai' o 'deepseek'")
 
 if LLM_PROVIDER == "openai" and not OPENAI_API_KEY:
     raise Exception(
-        "Devi impostare la variabile d'ambiente OPENAI_API_KEY oppure usare LLM_PROVIDER=deepseek"
+        "Variabile d'ambiente OPENAI_API_KEY mancante. "
+        "Imposta OPENAI_API_KEY e LLM_PROVIDER=openai oppure "
+        "fornisci DEEPSEEK_API_KEY e LLM_PROVIDER=deepseek."
     )
 if LLM_PROVIDER == "deepseek" and not DEEPSEEK_API_KEY:
-    raise Exception("Devi impostare la variabile d'ambiente DEEPSEEK_API_KEY")
+    raise Exception(
+        "Variabile d'ambiente DEEPSEEK_API_KEY mancante. "
+        "Imposta DEEPSEEK_API_KEY e LLM_PROVIDER=deepseek."
+    )
 
 VECTORDB_PATH = "vectordb/"
 if not os.path.isdir(VECTORDB_PATH):


### PR DESCRIPTION
## Summary
- Default to DeepSeek when only `DEEPSEEK_API_KEY` is provided
- Clarify missing API key errors and mention `LLM_PROVIDER`
- Document automatic DeepSeek selection in environment variables section

## Testing
- `python -m py_compile main.py`
- `LLM_PROVIDER=deepseek DEEPSEEK_API_KEY=dummy python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af37da9798832da26bade78791e650