### PR TITLE
chore: update default OpenAI model

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,8 +86,9 @@ try:
     retriever = db.as_retriever(search_kwargs={"k": 5})
 
     if LLM_PROVIDER == "openai":
+        # Default model can be overridden via OPENAI_MODEL and must exist in your account
         llm = ChatOpenAI(
-            model_name=os.getenv("OPENAI_MODEL", "gpt-5"),
+            model_name=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
             temperature=0,
             openai_api_key=OPENAI_API_KEY,
         )


### PR DESCRIPTION
## Summary
- default to `gpt-3.5-turbo` for OpenAI LLM and keep environment override

## Testing
- `OPENAI_API_KEY=dummy python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68b086619468832db8a1bcc86541efcd