### PR TITLE
Default to DeepSeek as LLM provider

### DIFF
--- a/index_documents.py
+++ b/index_documents.py
@@ -49,9 +49,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--provider",
-        default=os.getenv("LLM_PROVIDER", "openai"),
+        default=os.getenv("LLM_PROVIDER", "deepseek"),
         choices=["openai", "deepseek"],
-        help="Provider LLM da utilizzare (default: valore di LLM_PROVIDER)",
+        help="Provider LLM da utilizzare (default: deepseek)",
     )
     args = parser.parse_args()
 

--- a/rebuild_vectordb.py
+++ b/rebuild_vectordb.py
@@ -38,9 +38,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--provider",
-        default=os.getenv("LLM_PROVIDER", "openai"),
+        default=os.getenv("LLM_PROVIDER", "deepseek"),
         choices=["openai", "deepseek"],
-        help="Provider LLM da utilizzare (default: valore di LLM_PROVIDER)",
+        help="Provider LLM da utilizzare (default: deepseek)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- Set `deepseek` as the default LLM provider in indexing scripts
- Update CLI help text to reflect DeepSeek default

## Testing
- `python index_documents.py --help`
- `python rebuild_vectordb.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b1518f1274832da9bd857ea81da8c7