### PR TITLE
Handle blank LLM_PROVIDER env

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,8 +34,6 @@ app = FastAPI()
 
 @app.get("/")
 async def root():
-    if INIT_ERROR:
-        return JSONResponse(status_code=500, content={"error": INIT_ERROR})
     return FileResponse("static/index.html")
 
 
@@ -49,7 +47,11 @@ embeddings = None
 INIT_ERROR = None
 
 # Provider di default: DeepSeek, in linea con README e script ausiliari
-LLM_PROVIDER = os.getenv("LLM_PROVIDER", "deepseek").lower()
+_provider_env = os.getenv("LLM_PROVIDER")
+if not _provider_env or not _provider_env.strip():
+    LLM_PROVIDER = "deepseek"
+else:
+    LLM_PROVIDER = _provider_env.strip().lower()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
 DEEPSEEK_BASE_URL = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
@@ -125,11 +127,18 @@ try:
         )
 
     logger.info("✅ Ambiente base inizializzato correttamente.")
-except (openai.APIConnectionError, requests.exceptions.RequestException):
+except (openai.APIConnectionError, requests.exceptions.RequestException) as exc:
     provider_name = "OpenAI" if LLM_PROVIDER == "openai" else "DeepSeek"
-    INIT_ERROR = (
-        f"Impossibile contattare l'API {provider_name}; verifica rete o chiave"
-    )
+    if (
+        isinstance(exc, requests.exceptions.HTTPError)
+        and exc.response is not None
+        and exc.response.status_code == 401
+    ):
+        INIT_ERROR = f"Chiave API {provider_name} non valida"
+    else:
+        INIT_ERROR = (
+            f"Impossibile contattare l'API {provider_name}; verifica rete o chiave"
+        )
     logger.error(INIT_ERROR)
 except Exception:
     logger.exception("❌ Errore durante l'inizializzazione della pipeline RAG:")
@@ -530,6 +539,8 @@ async def ask_question(request: Request):
 
 @app.get("/health")
 async def health():
+    if INIT_ERROR:
+        return {"status": "error", "detail": INIT_ERROR}
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- trim and default LLM_PROVIDER to `deepseek` when env var is unset or blank
- clarify startup errors by detecting invalid API keys vs network issues
- always serve `static/index.html` and surface init errors via `/health`

## Testing
- `DEEPSEEK_API_KEY=dummy python - <<'PY'
from fastapi.testclient import TestClient
import main
client = TestClient(main.app)
print('root', client.get('/').status_code)
print('health', client.get('/health').json())
PY`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1d0bb04e8832dbca1f84515597e29