### PR TITLE
Add langchain-deepseek dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tiktoken>=0.5.0
 unstructured>=0.7.0
 pinecone-client>=2.3.0
 requests>=2.31.0
+langchain-deepseek>=0.1.0


### PR DESCRIPTION
## Summary
- add langchain-deepseek dependency to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement langchain-deepseek>=0.1.0)*
- `python -m py_compile main.py`
- `timeout 5s python main.py` *(fails: Exception: Variabile d'ambiente DEEPSEEK_API_KEY mancante. Imposta DEEPSEEK_API_KEY e LLM_PROVIDER=deepseek.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b4cdb4bc832d96e0cb8f33c69a93