### PR TITLE
Use ChatDeepSeek for DeepSeek provider

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from fastapi.staticfiles import StaticFiles
 
 # LangChain / OpenAI
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
+from langchain_deepseek import ChatDeepSeek
 from langchain_community.vectorstores import FAISS
 from langchain.chains import RetrievalQA
 from langchain.prompts import PromptTemplate
@@ -118,12 +119,11 @@ try:
             openai_api_key=OPENAI_API_KEY,
         )
     else:  # deepseek
-        llm = ChatOpenAI(
-            model_name=os.getenv("DEEPSEEK_MODEL", "deepseek-chat"),
-            temperature=0,
-            openai_api_key=DEEPSEEK_API_KEY,
+        llm = ChatDeepSeek(
+            api_key=DEEPSEEK_API_KEY,
             base_url=DEEPSEEK_BASE_URL,
-            default_headers={"Authorization": f"Bearer {DEEPSEEK_API_KEY}"},
+            model=os.getenv("DEEPSEEK_MODEL", "deepseek-chat"),
+            temperature=0,
         )
 
     logger.info("✅ Ambiente base inizializzato correttamente.")


### PR DESCRIPTION
## Summary
- Import ChatDeepSeek and use it for the DeepSeek provider

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: No module named 'langchain_deepseek')*
- `pip install langchain-deepseek` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b4cff5d0832d94edb0ad894f26c4