### PR TITLE
Use DeepSeek v1 models endpoint for ping

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,7 +93,7 @@ try:
         ping_url = "https://api.openai.com/v1/models"
         headers = {"Authorization": f"Bearer {OPENAI_API_KEY}"}
     else:  # deepseek
-        ping_url = f"{DEEPSEEK_BASE_URL.rstrip('/')}/models"
+        ping_url = f"{DEEPSEEK_BASE_URL.rstrip('/')}/v1/models"
         headers = {"Authorization": f"Bearer {DEEPSEEK_API_KEY}"}
     requests.get(ping_url, headers=headers, timeout=3).raise_for_status()
 


### PR DESCRIPTION
## Summary
- ensure DeepSeek startup check targets `/v1/models`
- confirm default `DEEPSEEK_BASE_URL` remains `https://api.deepseek.com`

## Testing
- `DEEPSEEK_API_KEY=dummy python main.py` *(fails: Impossibile contattare l'API DeepSeek; verifica rete o chiave)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b4d19a9c832da909b57fe9722534