### PR TITLE
Add temporary debug ping endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -544,6 +544,19 @@ async def health():
     return {"status": "ok"}
 
 
+@app.get("/debug/ping")
+async def debug_ping():
+    try:
+        r = requests.get(
+            f"{DEEPSEEK_BASE_URL.rstrip('/')}/v1/models",
+            headers={"Authorization": f"Bearer {DEEPSEEK_API_KEY}"},
+            timeout=5,
+        )
+        return {"status": r.status_code, "body": r.json()}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 @app.get("/agents")
 async def list_agents():
     """Restituisce l'elenco degli agenti configurati."""


### PR DESCRIPTION
## Summary
- add `/debug/ping` endpoint to verify DeepSeek API connectivity

## Testing
- `python -m py_compile main.py`
- `timeout 5s python main.py` *(fails: ModuleNotFoundError: No module named 'langchain_deepseek')*


------
https://chatgpt.com/codex/tasks/task_e_68b2c43d9b60832da2ffc3c5e8101b08