### PR TITLE
Add DeepSeek connection error logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,6 +139,8 @@ except (openai.APIConnectionError, requests.exceptions.RequestException) as exc:
         INIT_ERROR = (
             f"Impossibile contattare l'API {provider_name}; verifica rete o chiave"
         )
+    logger.error("Errore DeepSeek: %s", exc)
+    logger.debug(traceback.format_exc())
     logger.error(INIT_ERROR)
 except Exception:
     logger.exception("❌ Errore durante l'inizializzazione della pipeline RAG:")


### PR DESCRIPTION
## Summary
- log underlying DeepSeek exceptions during initialization
- include stack trace at debug level

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'langchain_deepseek')*
- `pip install langchain-deepseek` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c4384570832d9fb5a06355335012