### PR TITLE
Install ca-certificates before Python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 # Copia tutto
 COPY . .
 
+# Installa i certificati
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
 # Installa le dipendenze
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary
- Install system CA certificates before Python dependency installation in Dockerfile

## Testing
- `python -m py_compile main.py`
- `docker build -t rag-carletti:latest .` *(fails: command not found: docker)*
- `railway --version` *(fails: command not found: railway)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c4368c14832dad9d64950127922e