### PR TITLE
feat: make DeepSeek timeout configurable and log HTTP errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
    # Per usare OpenAI:
    # export OPENAI_API_KEY=<chiave per OpenAI>
    # export LLM_PROVIDER=openai
-   export BING_SEARCH_API_KEY=<opzionale per immagini>
-   export OPENAI_MODEL=<modello opzionale>
-   export ENABLE_IMAGE_SEARCH=true  # disabilita con false
-   ```
+    export BING_SEARCH_API_KEY=<opzionale per immagini>
+    export OPENAI_MODEL=<modello opzionale>
+    export ENABLE_IMAGE_SEARCH=true  # disabilita con false
+    export DEEPSEEK_TIMEOUT=10       # timeout API DeepSeek (s)
+    ```
 
 3. **Avvio dell'applicazione**
    ```bash


### PR DESCRIPTION
## Summary
- allow configuring DeepSeek startup ping timeout via `DEEPSEEK_TIMEOUT`
- log HTTP status and body when DeepSeek API returns an HTTP error and return the details through `INIT_ERROR`
- document `DEEPSEEK_TIMEOUT` variable

## Testing
- `DEEPSEEK_API_KEY=foo DEEPSEEK_BASE_URL=https://httpbin.org python main.py` *(fails to contact DeepSeek, as expected)*
- `DEEPSEEK_API_KEY=foo DEEPSEEK_BASE_URL=https://httpbin.org uvicorn main:app --port 8000 &`
- `curl -sS -X POST localhost:8000/ask -H 'Content-Type: application/json' -d '{"query":"ciao"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc527c98832dab0f3ff62f0979d7