### PR TITLE
Trim whitespace from API keys

### DIFF
--- a/index_documents.py
+++ b/index_documents.py
@@ -60,6 +60,8 @@ def main() -> None:
     provider = args.provider.lower()
     if provider == "openai":
         api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            api_key = api_key.strip()
         if not api_key:
             raise Exception(
                 "Devi impostare la variabile d'ambiente OPENAI_API_KEY oppure usare --provider deepseek"
@@ -67,6 +69,8 @@ def main() -> None:
         embeddings = OpenAIEmbeddings(openai_api_key=api_key)
     else:  # deepseek
         api_key = os.getenv("DEEPSEEK_API_KEY")
+        if api_key:
+            api_key = api_key.strip()
         base_url = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
         if not api_key:
             raise Exception(

--- a/main.py
+++ b/main.py
@@ -54,7 +54,12 @@ if not _provider_env or not _provider_env.strip():
 else:
     LLM_PROVIDER = _provider_env.strip().lower()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if OPENAI_API_KEY:
+    OPENAI_API_KEY = OPENAI_API_KEY.strip()
+
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
+if DEEPSEEK_API_KEY:
+    DEEPSEEK_API_KEY = DEEPSEEK_API_KEY.strip()
 DEEPSEEK_BASE_URL = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
 DEEPSEEK_TIMEOUT = float(os.getenv("DEEPSEEK_TIMEOUT", "10"))
 BING_SEARCH_API_KEY = os.getenv("BING_SEARCH_API_KEY")

--- a/rebuild_vectordb.py
+++ b/rebuild_vectordb.py
@@ -49,6 +49,8 @@ def main() -> None:
     provider = args.provider.lower()
     if provider == "openai":
         api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            api_key = api_key.strip()
         if not api_key:
             raise Exception(
                 "Devi impostare la variabile d'ambiente OPENAI_API_KEY oppure usare --provider deepseek"
@@ -56,6 +58,8 @@ def main() -> None:
         embeddings = OpenAIEmbeddings(openai_api_key=api_key)
     else:  # deepseek
         api_key = os.getenv("DEEPSEEK_API_KEY")
+        if api_key:
+            api_key = api_key.strip()
         base_url = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
         if not api_key:
             raise Exception(


### PR DESCRIPTION
## Summary
- Strip leading/trailing whitespace from `OPENAI_API_KEY` and `DEEPSEEK_API_KEY`
- Apply the same sanitisation in vector DB helper scripts

## Testing
- `DEEPSEEK_API_KEY=$'testkey\n' LLM_PROVIDER=deepseek python main.py > /tmp/server.log 2>&1` *(fails: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ce600790832d8e35f993d0b7cbc0