### PR TITLE
Sanitize API keys with regex

### DIFF
--- a/index_documents.py
+++ b/index_documents.py
@@ -14,6 +14,7 @@ from langchain_community.document_loaders import TextLoader, DirectoryLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 import argparse
 import os
+import re
 
 
 def load_txt_documents() -> list:
@@ -61,7 +62,7 @@ def main() -> None:
     if provider == "openai":
         api_key = os.getenv("OPENAI_API_KEY")
         if api_key:
-            api_key = api_key.strip()
+            api_key = re.sub(r"\s+", "", api_key or "")
         if not api_key:
             raise Exception(
                 "Devi impostare la variabile d'ambiente OPENAI_API_KEY oppure usare --provider deepseek"
@@ -70,7 +71,7 @@ def main() -> None:
     else:  # deepseek
         api_key = os.getenv("DEEPSEEK_API_KEY")
         if api_key:
-            api_key = api_key.strip()
+            api_key = re.sub(r"\s+", "", api_key or "")
         base_url = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
         if not api_key:
             raise Exception(

--- a/main.py
+++ b/main.py
@@ -55,11 +55,11 @@ else:
     LLM_PROVIDER = _provider_env.strip().lower()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if OPENAI_API_KEY:
-    OPENAI_API_KEY = OPENAI_API_KEY.strip()
+    OPENAI_API_KEY = re.sub(r"\s+", "", OPENAI_API_KEY or "")
 
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
 if DEEPSEEK_API_KEY:
-    DEEPSEEK_API_KEY = DEEPSEEK_API_KEY.strip()
+    DEEPSEEK_API_KEY = re.sub(r"\s+", "", DEEPSEEK_API_KEY or "")
 DEEPSEEK_BASE_URL = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
 DEEPSEEK_TIMEOUT = float(os.getenv("DEEPSEEK_TIMEOUT", "10"))
 BING_SEARCH_API_KEY = os.getenv("BING_SEARCH_API_KEY")

--- a/rebuild_vectordb.py
+++ b/rebuild_vectordb.py
@@ -12,6 +12,7 @@ from langchain_community.document_loaders import TextLoader, DirectoryLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 import argparse
 import os
+import re
 
 
 def load_txt_documents() -> list:
@@ -50,7 +51,7 @@ def main() -> None:
     if provider == "openai":
         api_key = os.getenv("OPENAI_API_KEY")
         if api_key:
-            api_key = api_key.strip()
+            api_key = re.sub(r"\s+", "", api_key or "")
         if not api_key:
             raise Exception(
                 "Devi impostare la variabile d'ambiente OPENAI_API_KEY oppure usare --provider deepseek"
@@ -59,7 +60,7 @@ def main() -> None:
     else:  # deepseek
         api_key = os.getenv("DEEPSEEK_API_KEY")
         if api_key:
-            api_key = api_key.strip()
+            api_key = re.sub(r"\s+", "", api_key or "")
         base_url = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
         if not api_key:
             raise Exception(


### PR DESCRIPTION
## Summary
- Remove whitespace in API keys using regex
- Import `re` in indexing utilities and vector DB rebuild script

## Testing
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python3 - <<'PY'\nimport os, re\napi_key = os.getenv('DEEPSEEK_API_KEY')\nprint('raw:', repr(api_key))\napi_key = re.sub(r"\\s+", "", api_key or "")\nprint('sanitized:', api_key)\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68b864b37bac832d843336f400b9b7b1