### PR TITLE
feat: add DeepSeek debug endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,20 @@ implementate nel codice nella variabile `AGENT_PROMPTS` di `main.py`.
    # Per usare OpenAI:
    # export OPENAI_API_KEY=<chiave per OpenAI>
    # export LLM_PROVIDER=openai
-    export BING_SEARCH_API_KEY=<opzionale per immagini>
-    export OPENAI_MODEL=<modello opzionale>
+   export BING_SEARCH_API_KEY=<opzionale per immagini>
+   export OPENAI_MODEL=<modello opzionale>
     export ENABLE_IMAGE_SEARCH=true  # disabilita con false
     export DEEPSEEK_TIMEOUT=10       # timeout API DeepSeek (s)
+    export DEEPSEEK_BASE_URL=https://api.deepseek.com  # senza suffisso /v1
     ```
+
+   Per controllare la connettività con DeepSeek è disponibile un endpoint di debug:
+
+   ```bash
+   curl http://localhost:8000/debug/ping-deepseek
+   ```
+
+   L'API restituisce lo status HTTP e il corpo della chiamata a `/v1/models`.
 
 3. **Avvio dell'applicazione**
    ```bash

--- a/main.py
+++ b/main.py
@@ -38,6 +38,23 @@ async def root():
     return FileResponse("static/index.html")
 
 
+@app.get("/debug/ping-deepseek")
+async def debug_ping_deepseek():
+    """Ping di debug verso l'endpoint DeepSeek /v1/models."""
+    ping_url = f"{DEEPSEEK_BASE_URL.rstrip('/')}/v1/models"
+    if not DEEPSEEK_API_KEY:
+        return JSONResponse(
+            {"error": "DEEPSEEK_API_KEY non configurata"}, status_code=500
+        )
+    headers = {"Authorization": f"Bearer {DEEPSEEK_API_KEY}"}
+    try:
+        resp = requests.get(ping_url, headers=headers, timeout=DEEPSEEK_TIMEOUT)
+        return JSONResponse({"status": resp.status_code, "body": resp.text})
+    except Exception as exc:
+        logger.error("Errore pingando DeepSeek: %s", exc)
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 CONVERSATIONS: dict[str, ConversationBufferMemory] = {}


### PR DESCRIPTION
## Summary
- add `/debug/ping-deepseek` endpoint to check DeepSeek API connectivity
- document `DEEPSEEK_BASE_URL` variable and debug endpoint in README

## Testing
- `python -m py_compile main.py`
- `OPENAI_API_KEY=dummy LLM_PROVIDER=openai python main.py` *(fails: HTTPSConnectionPool(host='api.openai.com', port=443): Max retries exceeded with url: /v1/models (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68b872529a64832db6b30dfd7e5cc077