### PR TITLE
feat: support external embeddings and add ask schema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ unstructured>=0.7.0
 pinecone-client>=2.3.0
 requests>=2.31.0
 langchain-deepseek>=0.1.0
+sentence-transformers>=0.5.0


### PR DESCRIPTION
## Summary
- add `AskRequest` model for documented `/ask` payload and update endpoint signature
- allow using OpenAI or HuggingFace embeddings via `EMBEDDINGS_PROVIDER` with safe fallback
- build RAG chains defensively with graceful LLM-only fallback

## Testing
- `python -m py_compile main.py`
- `DEEPSEEK_API_KEY=test uvicorn main:app --host 0.0.0.0 --port 8000 &`
- `curl -sS http://localhost:8000/health`
- `curl -sS http://localhost:8000/debug/ping`


------
https://chatgpt.com/codex/tasks/task_e_68b9c471a6e8832d833f1d6897f04a07