### PR TITLE
Restore hypothesis highlight and escape import

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
 import json
 import logging
-import traceback
 import os
 import re
 import asyncio
+import traceback
+from html import escape
 import requests
 import openai
 from datetime import datetime

--- a/static/index.html
+++ b/static/index.html
@@ -298,6 +298,9 @@
           msg.textContent = sanitized;
         } else {
           msg.innerHTML = sanitized;
+          if (msg.querySelector('.ipotesi-lista')) {
+            msg.classList.add('has-hypotheses');
+          }
           if (!options.skipFeedback && options.agentId) {
             msg.appendChild(createFeedbackForm(options.agentId));
           }


### PR DESCRIPTION
## Summary
- restore the `has-hypotheses` CSS class assignment when rendering assistant messages containing `.ipotesi-lista`
- add the missing `html.escape` import to align with the merged Python code

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68cc782b1da0832dbf6b4075b7322a92