### PR TITLE
Add visual feedback indicator to bot messages

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -166,6 +166,26 @@
       color: var(--accent);
     }
 
+    .feedback-emoji {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-left: 0.5rem;
+      min-width: 1.5rem;
+      color: transparent;
+      transition: color 0.2s ease-in-out;
+    }
+
+    .feedback-emoji.positive {
+      color: #2e7d32;
+    }
+
+    .feedback-emoji.negative {
+      color: #c62828;
+    }
+
     .feedback-form.disabled {
       opacity: 0.7;
       pointer-events: none;
@@ -299,14 +319,18 @@
         } else {
           msg.innerHTML = sanitized;
           if (!options.skipFeedback && options.agentId) {
-            msg.appendChild(createFeedbackForm(options.agentId));
+            const feedbackEmoji = document.createElement('span');
+            feedbackEmoji.classList.add('feedback-emoji');
+            feedbackEmoji.setAttribute('aria-hidden', 'true');
+            msg.appendChild(feedbackEmoji);
+            msg.appendChild(createFeedbackForm(options.agentId, feedbackEmoji));
           }
         }
         chatContainer.appendChild(msg);
         chatContainer.scrollTop = chatContainer.scrollHeight;
       }
 
-      function createFeedbackForm(agentId) {
+      function createFeedbackForm(agentId, feedbackEmoji) {
         const form = document.createElement('form');
         form.classList.add('feedback-form');
         form.setAttribute('aria-label', 'Invia un feedback sulla risposta del bot');
@@ -363,6 +387,13 @@
             return;
           }
 
+          if (feedbackEmoji) {
+            feedbackEmoji.textContent = '';
+            feedbackEmoji.classList.remove('positive', 'negative');
+            feedbackEmoji.setAttribute('aria-hidden', 'true');
+            feedbackEmoji.removeAttribute('aria-label');
+          }
+
           const payload = {
             session_id: sessionId,
             agent_id: agentId,
@@ -398,6 +429,19 @@
             }
             status.textContent = '✅ Feedback inviato, grazie!';
             form.classList.add('disabled');
+            if (feedbackEmoji) {
+              const positive = payload.rating >= 4;
+              feedbackEmoji.textContent = positive ? 'V' : 'X';
+              feedbackEmoji.classList.remove('positive', 'negative');
+              feedbackEmoji.classList.add(positive ? 'positive' : 'negative');
+              feedbackEmoji.removeAttribute('aria-hidden');
+              feedbackEmoji.setAttribute(
+                'aria-label',
+                positive
+                  ? 'Feedback positivo: la risposta è stata considerata corretta'
+                  : 'Feedback negativo: la risposta è stata considerata errata'
+              );
+            }
           } catch (error) {
             status.textContent = `❌ ${error.message}`;
             status.classList.add('error');


### PR DESCRIPTION
## Summary
- add CSS styles to display green V or red X feedback emoji on bot messages
- attach a feedback emoji to each feedback form and update it after successful submissions with descriptive ARIA labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc7a4821ac832dbb3cebebf0fe4138