### PR TITLE
Fix hypothesis prompt escaping

### DIFF
--- a/main.py
+++ b/main.py
@@ -525,12 +525,12 @@ def classify_query(question: str) -> int:
 HYPOTHESIS_EXTRACTION_PROMPT = """
 Analizza la domanda e la risposta fornite.
 Restituisci esclusivamente un JSON valido con questa struttura:
-{
+{{
   "spiegazione": "riassunto tecnico della risposta in italiano",
   "hypotheses": [
-    {"label": "descrizione sintetica dell'ipotesi", "confidence": percentuale intera tra 0 e 100}
+    {{"label": "descrizione sintetica dell'ipotesi", "confidence": percentuale intera tra 0 e 100}}
   ]
-}
+}}
 Includi al massimo tre ipotesi rilevanti. Se non hai ipotesi attendibili usa un array vuoto.
 Non aggiungere commenti, testo fuori dal JSON o blocchi di codice.
 Domanda: {question}


### PR DESCRIPTION
## Summary
- escape the JSON braces in the hypothesis extraction prompt so it can be formatted safely
- avoid KeyError raised when formatting the prompt during structured answer generation

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd7fd595c4832dafaacc0bbe08956a