### PR TITLE
Add mobile-friendly layout for chat controls

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -298,6 +298,24 @@
       cursor: pointer;
     }
 
+    @media (max-width: 600px) {
+      #input-container {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.4rem;
+      }
+
+      #prompt,
+      #agent-select,
+      #send-btn {
+        width: 100%;
+      }
+
+      #send-btn {
+        min-height: 44px;
+      }
+    }
+
     .footnotes {
       font-size: 0.875rem;
       margin-top: 1rem;


### PR DESCRIPTION
## Summary
- add a mobile media query for the chat input container to stack controls on small screens
- stretch the prompt field, agent selector, and send button to full width with an accessible button height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2a12cd75c832da788c29e2e41be56